### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Json for swop.fi
 ## Token Decimals
 1) sUSDT_USD-N:  6 decimals
 2) sNSBT_USD-N:  6 decimals
-3) WAVES/USDN: 6 decimals
+3) WAVES/USDN: 7 decimals
 4) sUSDLP_USD-N: 6 decimals
 5) sSWOP_USD-N: 7 decimals
 


### PR DESCRIPTION
fix: waves/usdn has 7 decimals